### PR TITLE
Fix: make available only for tex files

### DIFF
--- a/lua/cmp_vimtex/source.lua
+++ b/lua/cmp_vimtex/source.lua
@@ -43,7 +43,7 @@ source.new = function(options)
 end
 
 source.is_available = function()
-  return vim.bo.omnifunc ~= "" and vim.api.nvim_get_mode().mode == "i"
+  return vim.bo.omnifunc == "vimtex#complete#omnifunc"
 end
 
 source.get_position_encoding_kind = function()


### PR DESCRIPTION
Before this, `cmp-vimtex` triggered omni-completion for any buffer with nonempty value of `omnifunc` (such as `v:lua.vim.lsp.omnifunc` set by a language server, causing a weird behaviour with `cmp-nvim-lsp`).