### PR TITLE
Fix: handle nonexistent `vimtex.root`

### DIFF
--- a/lua/cmp_vimtex/source.lua
+++ b/lua/cmp_vimtex/source.lua
@@ -14,7 +14,7 @@ local defaults = {
 }
 
 source.start_parser = function(self)
-  if not vim.uv.fs_stat(vim.b.vimtex.root) then
+  if not vim.loop.fs_stat(vim.b.vimtex.root) then
     return
   end
 

--- a/lua/cmp_vimtex/source.lua
+++ b/lua/cmp_vimtex/source.lua
@@ -14,6 +14,10 @@ local defaults = {
 }
 
 source.start_parser = function(self)
+  if not vim.uv.fs_stat(vim.b.vimtex.root) then
+    return
+  end
+
   local parser = require "cmp_vimtex.parser"
 
   vim.cmd [[call vimtex#paths#pushd(b:vimtex.root)]]


### PR DESCRIPTION
It can happen that `vimtex.root` is not a proper directory (for example with plugin `gitsigns.nvim`, the diff window has `vimtex.root` as something like `gitsigns:///dirpath/.git`), leading to errors in `vimtex#paths#pushd(b:vimtex.root)`.

It seems that not starting the parser in such buffers works alright, but I'm not sure if it is the right/optimal solution.