### PR TITLE
fixed error during lauch

### DIFF
--- a/lua/cmp_vimtex/init.lua
+++ b/lua/cmp_vimtex/init.lua
@@ -16,11 +16,6 @@ M.setup = function(options)
     group = group,
     callback = _start_parser,
   })
-
-  -- Start bibtex_parser now if we are already in a LaTeX buffer
-  if vim.opt_local.filetype:get() == "tex" then
-    _start_parser()
-  end
 end
 
 M.url_default_format = function(url)


### PR DESCRIPTION
After setting up the autocmd, the function ` _start_parser` will be called for the current buffer. There's no reason to call it again. And calling the function from init.lua leads to a problem to the code `vim.loop.fs_stat(vim.b.vimtex.root)` at line 69 in `source.lua` since b:vimtex can be nil at this point. Removing the redundant call to `_start_parser` resolves the issue.