### PR TITLE
Suppress error fired sometimes by `vimtex#bib#files`

### DIFF
--- a/lua/cmp_vimtex/source.lua
+++ b/lua/cmp_vimtex/source.lua
@@ -73,12 +73,14 @@ source.start_parser = function(self)
   local parser = require "cmp_vimtex.parser"
 
   vim.fn["vimtex#paths#pushd"](vim.b.vimtex.root)
-  local files = vim.fn["vimtex#bib#files"]()
-  for _, file in pairs(files) do
-    if self.bib_files[file] == nil then
-      local new_parser = parser.new(file)
-      new_parser:start_parsing()
-      self.bib_files[file] = new_parser
+  local success, files = pcall(vim.fn["vimtex#bib#files"])
+  if success then
+    for _, file in pairs(files) do
+      if self.bib_files[file] == nil then
+        local new_parser = parser.new(file)
+        new_parser:start_parsing()
+        self.bib_files[file] = new_parser
+      end
     end
   end
   vim.fn["vimtex#paths#popd"]()

--- a/lua/cmp_vimtex/source.lua
+++ b/lua/cmp_vimtex/source.lua
@@ -82,7 +82,10 @@ source.start_parser = function(self)
         self.bib_files[file] = new_parser
       end
     end
+  else
+    print("cmp-vimtex: error when calling vimtex#bib#files in source.lua")
   end
+
   vim.fn["vimtex#paths#popd"]()
 end
 


### PR DESCRIPTION
When opening `.sty` files, I would get the following error
```
Vim(append):Error executing lua callback: BufReadPost Autocommands for "*"..FileType Autocommands
for "tex" ..function vimtex#bib#files, line 14: Vim (let):E716: Key not present in Dictionary: "compiler"
```

I just wrapped the call in `pcall` and returned from function if the call was not successful, not sure if it is the right solution though.
